### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "shogi_official_kifu"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "shogi_core",
  "shogi_legality_lite",

--- a/shogi_official_kifu/Cargo.toml
+++ b/shogi_official_kifu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shogi_official_kifu"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Rust shogi crates developers"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Milestone: https://github.com/rust-shogi-crates/shogi_official_kifu/milestone/2?closed=1

Changes made in 0.1.1 -> 0.1.2:
- Update dependent libraries (https://github.com/rust-shogi-crates/shogi_official_kifu/pull/7, https://github.com/rust-shogi-crates/shogi_official_kifu/pull/10)
- Use illegal moves for disambiguation (https://github.com/rust-shogi-crates/shogi_official_kifu/pull/6)
- Place LICENSE file on the project root (https://github.com/rust-shogi-crates/shogi_official_kifu/pull/9)